### PR TITLE
fixing docker for use on linux (volumes belong to root)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The graph has been made using scalar types, enumerables, lists, interfaces and c
 
 These instructions assume you already have `docker` and `docker-compose` installed. Common actions are as follows:
 
-To start the Apollo server and example client in development mode, run the following:
+In order to correctly run the client container, we need to start the server container. This is because when the client starts itself, it will generate types and hooks for use within the application. There is a single command that will build the dev versions of both the client and server images (if necessary), start the server container, wait for the server to be responsive, then start the client container:
 
 ```shell
     make start-apollo-client-dev

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,20 +1,26 @@
-FROM node:16.15.1-alpine
+FROM node:16.15.1-alpine AS base
 
 LABEL maintainer="Anthony Hastings <ar.hastings@gmail.com>"
+
+WORKDIR /home/node/apollo-client
+
+COPY package.json package-lock.json ./
+
+RUN npm install
+
+COPY . ./
+
+FROM node:16.15.1-alpine AS client
 
 ENV DOCKERIZE_VERSION v0.6.1
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
   && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
   && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
-USER node
-
 WORKDIR /home/node/apollo-client
 
-COPY --chown=node package.json package-lock.json ./
+COPY --from=base --chown=node /home/node/apollo-client ./
 
-RUN npm install
-
-COPY --chown=node . ./
+USER node
 
 CMD npm start

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -7,8 +7,6 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
   && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
   && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
-USER node
-
 WORKDIR /home/node/apollo-server
 
 COPY --chown=node package.json package-lock.json ./
@@ -19,9 +17,9 @@ COPY --chown=node . ./
 
 RUN npm run build
 
-FROM node:16.15.1-alpine AS server
-
 USER node
+
+FROM node:16.15.1-alpine AS server
 
 WORKDIR /home/node/apollo-server
 
@@ -30,5 +28,7 @@ COPY --from=base --chown=node /home/node/apollo-server/package.json /home/node/a
 RUN npm ci
 
 COPY --from=base --chown=node /home/node/apollo-server/dist ./dist
+
+USER node
 
 CMD npm start


### PR DESCRIPTION
Originally I built this on Mac OS but when trying it on linux the docker images failed to build. There's a few reasons but the TL:DR is that on linux things are slightly diffferent. Volumes mount as root etc...