### PR TITLE
Adding sort to getBuyers with defaults

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "client",
-  "version": "0.1.0",
+  "name": "apollo-nexus-client",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "client",
-      "version": "0.1.0",
+      "name": "apollo-nexus-client",
+      "version": "1.0.0",
+      "license": "MIT",
       "dependencies": {
         "@apollo/client": "3.6.9",
         "graphql": "16.5.0",

--- a/server/src/contexts/dummy-api.mts
+++ b/server/src/contexts/dummy-api.mts
@@ -1,5 +1,8 @@
 import { DataSource } from 'apollo-datasource';
-import type { NexusGenRootTypes } from '../../artifacts/nexus-typegen.mjs';
+import type {
+  NexusGenEnums,
+  NexusGenRootTypes,
+} from '../../artifacts/nexus-typegen.mjs';
 
 type UpdateBuyerAttributes = Partial<Omit<NexusGenRootTypes['Buyer'], 'id'>>;
 
@@ -85,8 +88,25 @@ class DummyAPI extends DataSource {
     return orders;
   }
 
-  async getBuyers() {
-    console.log('DummyAPI::getBuyers');
+  async getBuyers({
+    sortField,
+    sortDirection,
+  }: {
+    sortField?: NexusGenEnums['BuyerSortableColumns'];
+    sortDirection?: NexusGenEnums['SortDirection'];
+  }) {
+    console.log('DummyAPI::getBuyers', sortField, sortDirection);
+
+    if (sortField && sortDirection) {
+      const sortedResults = [...buyers].sort((elementOne, elementTwo) => {
+        return elementOne[sortField]
+          .toLowerCase()
+          .localeCompare(elementTwo[sortField].toLowerCase());
+      });
+
+      return sortDirection === 'DESC' ? sortedResults.reverse() : sortedResults;
+    }
+
     return buyers;
   }
 

--- a/server/src/schemas/Common.mts
+++ b/server/src/schemas/Common.mts
@@ -1,0 +1,7 @@
+import { enumType } from 'nexus';
+
+export const SortDirection = enumType({
+  name: 'SortDirection',
+  description: 'Order of sort when querying record(s).',
+  members: ['ASC', 'DESC'],
+});

--- a/server/src/schemas/index.mts
+++ b/server/src/schemas/index.mts
@@ -1,4 +1,5 @@
 export * from './Buyer.mjs';
+export * from './Common.mjs';
 export * from './ISODateString.mjs';
 export * from './Order.mjs';
 export * from './OrderStatus.mjs';


### PR DESCRIPTION
This showcases best practices:
- Making the schema expressive.
- Making sorting optional.
- Ensuring the default sorting isn't hidden inside / baked into the resolver, but is placed about the queries argument itself. This allows the defaults to be documented and indicate to the caller what the default behaviour is.