### PR TITLE
Adding dataloader package

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "apollo-datasource": "3.3.2",
         "apollo-server": "3.9.0",
+        "dataloader": "2.1.0",
         "dotenv": "16.0.1",
         "graphql": "16.5.0",
         "luxon": "2.4.0",
@@ -1077,6 +1078,11 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
       "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
+    },
+    "node_modules/dataloader": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.1.0.tgz",
+      "integrity": "sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ=="
     },
     "node_modules/debug": {
       "version": "3.2.7",
@@ -3659,6 +3665,11 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
       "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
+    },
+    "dataloader": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.1.0.tgz",
+      "integrity": "sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ=="
     },
     "debug": {
       "version": "3.2.7",

--- a/server/package.json
+++ b/server/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "apollo-datasource": "3.3.2",
     "apollo-server": "3.9.0",
+    "dataloader": "2.1.0",
     "dotenv": "16.0.1",
     "graphql": "16.5.0",
     "luxon": "2.4.0",

--- a/server/src/contexts/dummy-api.mts
+++ b/server/src/contexts/dummy-api.mts
@@ -1,4 +1,5 @@
 import { DataSource } from 'apollo-datasource';
+import DataLoader from 'dataloader';
 import type {
   NexusGenEnums,
   NexusGenRootTypes,
@@ -102,6 +103,10 @@ let warehouses: Array<NexusGenRootTypes['Warehouse']> = [
 ];
 
 class DummyAPI extends DataSource {
+  private warehouseLoader = new DataLoader((ids: readonly string[]) => {
+    return this.getWarehousesById(ids);
+  });
+
   constructor() {
     console.log('DummyAPI::constructor');
     super();
@@ -145,8 +150,14 @@ class DummyAPI extends DataSource {
   }
 
   async getWarehouse(id: string) {
-    console.log('DummyAPI::getWarehouse', id);
-    return warehouses.find((warehouse) => warehouse.id === id);
+    console.log('DummyAPI::getWarehouse (passthrough to dataloader)', id);
+    const warehouse = await this.warehouseLoader.load(id);
+    return warehouse;
+  }
+
+  async getWarehousesById(ids: readonly string[]) {
+    console.log('DummyAPI::getWarehousesById', ids);
+    return ids.map((id) => warehouses.find((warehouse) => warehouse.id === id));
   }
 
   async updateBuyer(

--- a/server/src/contexts/dummy-api.mts
+++ b/server/src/contexts/dummy-api.mts
@@ -32,6 +32,7 @@ let orders: Array<NexusGenRootTypes['Order']> = [
     sellerId: 'fake-seller-01',
     shippedAt: '2022-06-19T15:00:00+01:00',
     status: 'PAID',
+    warehouseId: 'fake-warehouse-01',
   },
   {
     id: 'fake-order-02',
@@ -40,6 +41,16 @@ let orders: Array<NexusGenRootTypes['Order']> = [
     sellerId: 'fake-seller-02',
     shippedAt: null,
     status: 'PENDING',
+    warehouseId: 'fake-warehouse-01',
+  },
+  {
+    id: 'fake-order-03',
+    buyerId: 'fake-buyer-02',
+    price: 123,
+    sellerId: 'fake-seller-01',
+    shippedAt: null,
+    status: 'PENDING',
+    warehouseId: 'fake-warehouse-02',
   },
 ];
 
@@ -74,6 +85,19 @@ let sellers: Array<NexusGenRootTypes['Seller']> = [
     acceptedPaymentMethods: ['CASH'],
     isAcceptingOrders: false,
     shippingNotice: 'Currently between realms. Will re-open shop on my return.',
+  },
+];
+
+let warehouses: Array<NexusGenRootTypes['Warehouse']> = [
+  {
+    id: 'fake-warehouse-01',
+    name: 'The Box Factory',
+    address: 'Wayne Manor, Gotham',
+  },
+  {
+    id: 'fake-warehouse-02',
+    name: 'Box Emporium',
+    address: '21 Gresham Lane, Madeupville',
   },
 ];
 
@@ -118,6 +142,11 @@ class DummyAPI extends DataSource {
   async getSeller(id: string) {
     console.log('DummyAPI::getSeller', id);
     return sellers.find((seller) => seller.id === id);
+  }
+
+  async getWarehouse(id: string) {
+    console.log('DummyAPI::getWarehouse', id);
+    return warehouses.find((warehouse) => warehouse.id === id);
   }
 
   async updateBuyer(

--- a/server/src/schemas/Order.mts
+++ b/server/src/schemas/Order.mts
@@ -4,6 +4,7 @@ import { Buyer } from './Buyer.mjs';
 import { ISODateString } from './ISODateString.mjs';
 import { OrderStatus } from './OrderStatus.mjs';
 import { Seller } from './Seller.mjs';
+import { Warehouse } from './Warehouse.mjs';
 
 export const Order = objectType({
   name: 'Order',
@@ -38,6 +39,18 @@ export const Order = objectType({
     t.nonNull.field('status', {
       type: nonNull(OrderStatus),
       description: 'Status of an order.',
+    });
+    t.nonNull.id('warehouseId', {
+      description: 'Identifier of the warehouse storing the order.',
+    });
+    t.nonNull.field('warehouse', {
+      type: Warehouse,
+      description: 'Warehouse storing this order.',
+      resolve: async ({ warehouseId }, _, { dataSources }) => {
+        return (await dataSources.dummyAPI.getWarehouse(
+          warehouseId
+        )) as NonNullable<NexusGenRootTypes['Warehouse']>;
+      },
     });
     t.field('shippedAt', {
       type: ISODateString,

--- a/server/src/schemas/Warehouse.mts
+++ b/server/src/schemas/Warehouse.mts
@@ -1,0 +1,11 @@
+import { objectType } from 'nexus';
+
+export const Warehouse = objectType({
+  name: 'Warehouse',
+  description: 'A warehouse that stores items.',
+  definition(t) {
+    t.nonNull.id('id', { description: 'Identifier of this warehouse.' });
+    t.nonNull.string('name', { description: 'Name of this warehouse.' });
+    t.nonNull.string('address', { description: 'Address of this warehouse.' });
+  },
+});

--- a/server/src/schemas/index.mts
+++ b/server/src/schemas/index.mts
@@ -7,3 +7,4 @@ export * from './PaymentMethod.mjs';
 export * from './Person.mjs';
 export * from './Seller.mjs';
 export * from './UserError.mjs';
+export * from './Warehouse.mjs';


### PR DESCRIPTION
This PR adds a fictional use case of loading relational data belonging to an order, in this case, information on the warehouse storing the order. Below is an example query returning orders and their related warehouse information:
```gql
query ExampleQuery {
  getOrders {
    id
    buyerId
    sellerId
    warehouseId
    warehouse {
      id
      name
      address
    }
  }
}
```

## Initial Implementation: N+1 Problem
The first commit of this branch introduces the logic in a naive manner and causes an N+1 query problem which is best explained with the flow below:

1. The `getOrders` method does a single query to the data source to return all orders.
2. The returned array of order objects is iterated over, with each order object passed through the `Order` type / resolver.
3. The `warehouse` field's resolver is triggered which queries the data source for that particular warehouses information.

In total, we have made four queries to the data source; one request to retrieve the orders themselves ("+ 1") and then an additional request per order to retrieve that order's warehouse information ("N"). This can be seen in the log output after running the query:

```shell
DummyAPI::constructor

# Hypothetical database call
DummyAPI::getOrders 

# Hypothetical database call
DummyAPI::getWarehouse fake-warehouse-01

# Hypothetical database call
DummyAPI::getWarehouse fake-warehouse-01

# Hypothetical database call
DummyAPI::getWarehouse fake-warehouse-02
```

As well as the numerous requests, we can also see that some records and being duplicated and fetched numerous times. More than one order is related to `fake-warehouse-01` and it's data is therefore loaded multiple times.

## Final Implementation: Using dataloader
The [dataloader library](https://www.npmjs.com/package/dataloader) can be used to gather up all requests for data and then flush them in one go. It has the following benefits:
- ✅ Batches requests being made consecutively then flushes them on the next occurrence of `process.nextTick()`.
- ✅ De-dupes identifiers to ensure records are only requested once.

Using this pattern we have the following flow:
1. The `getOrders` method does a single query to the data source to return all orders.
2. The returned array of order objects is iterated over, with each order object passed through the Order type / resolver.
3. The warehouse field's resolver is triggered which calls the data loader instantiation with the warehouse's identifier.
4. Once the array of order objects has been iterated over and all calls for warehouse information have been placed, the data loader de-dupes the identifiers it was given, then triggers itself and does a single fetch to the data source for batched information.
5. The response from the data source is disseminated out to all of the promises in the resolvers that are awaiting the warehouse information to be loaded.

In total, we have made two queries to the data source; one to retrieve the orders themselves and then another query to retrieve warehouse information in batch. This can be seen in the log output after running the query:
```shell
DummyAPI::constructor

# Hypothetical database call
DummyAPI::getOrders

DummyAPI::getWarehouse (passthrough to dataloader) fake-warehouse-01
DummyAPI::getWarehouse (passthrough to dataloader) fake-warehouse-01
DummyAPI::getWarehouse (passthrough to dataloader) fake-warehouse-02

# Hypothetical database call
DummyAPI::getWarehousesById [ 'fake-warehouse-01', 'fake-warehouse-02' ]
```

_(Note: Dataloader caches results indefinitely and because of this, the dataloader should be instantiated per request. The way Apollo Server works, the `context` and `dataSources` arguments are constructor methods which [get called per request](https://www.apollographql.com/docs/apollo-server/data/resolvers/#the-context-argument:~:text=To%20provide%20an%20initial%20context%20to%20your%20resolvers%2C%20add%20a%20context%20initialization%20function%20to%20the%20ApolloServer%20constructor.%20This%20function%20is%20called%20with%20every%20request%2C%20so%20you%20can%20customize%20the%20context%20based%20on%20each%20request%27s%20details%20(such%20as%20HTTP%20headers).), so there's no caching issue in this example implementation :tada:)_

## Further Information
- [Dataloader Package](https://www.npmjs.com/package/dataloader)
- [Apollo Server: Using with Dataloader](https://www.apollographql.com/docs/apollo-server/data/data-sources/#using-with-dataloader)
- [Dataloader: source code walkthrough](https://www.youtube.com/watch?v=OQTnXNCDywA)
- [Tutorial - Part One (N+1 Issues)](https://levelup.gitconnected.com/do-not-resolve-your-graphql-fields-like-a-rest-endpoint-ac43242f269)
- [Tutorial - Part Two (Adding Dataloader)](https://levelup.gitconnected.com/solve-n-1-query-problem-in-graphql-with-dataloaders-18e16ac17b21)